### PR TITLE
Fixes for bugs encountered when trying small IDL files

### DIFF
--- a/lib/IDLParser/stage3.py
+++ b/lib/IDLParser/stage3.py
@@ -374,6 +374,8 @@ def generate_fast_cpp_specification(syntax, specs):
 
 def generate_cpp_code(syntax_list):
     includes  = ["BackendSpecializations", "BackendDirectClasses", "BackendSelectors"]
+    if syntax_list[0] == 'specification':
+        syntax_list = (syntax_list,)
     specs     = {spec[1] : spec[2] for spec in syntax_list}
 
     return "\n".join(["#include \"llvm/IDL/{}.hpp\"".format(s) for s in includes]

--- a/lib/IDLParser/stage3.py
+++ b/lib/IDLParser/stage3.py
@@ -394,6 +394,7 @@ def generate_cpp_code(syntax_list):
                     +["IdiomSpecification(*GenerateAnalysis(std::string name))(llvm::Function&, unsigned)"]
                     +["{"]
                     +["    if(name == \""+syntax[1]+"\") return Detect"+syntax[1]+";" for syntax in syntax_list]
+                    +["    std::cerr << \"Unknwon idiom \" << name;"]
                     +["    return nullptr;"]
                     +["}"])
 


### PR DESCRIPTION
Hi philip,

I encountered a couple issues while writing some IDL.

The changes in 'a5341' print the name of the idiom not found to cerr, which was extremely helpful when debugging where the unupdated names were in the C code.

The changes in '5e9a' fix a bug where the IDL parser failed with a single exported constraint in the IDL file.

Jackson