### PR TITLE
More cfg and dfg fixes in split_graph

### DIFF
--- a/lib/IDLSolver/FunctionWrap.cpp
+++ b/lib/IDLSolver/FunctionWrap.cpp
@@ -25,11 +25,11 @@ std::vector<std::vector<unsigned>> reverse_graph(const std::vector<std::vector<u
 
 std::vector<std::vector<std::vector<unsigned>>> split_graph(const std::vector<std::vector<unsigned>>& graph)
 {
-    std::vector<std::vector<std::vector<unsigned>>> result;
+    std::vector<std::vector<std::vector<unsigned>>> result(4, std::vector<std::vector<unsigned>>(graph.size()));
 
     for(unsigned i = 0; i < graph.size(); i++)
     {
-        while(result.size() < graph[i].size())
+        while(result.size() <= graph[i].size())
             result.emplace_back(graph.size());
 
         for(unsigned j = 0; j < graph[i].size(); j++)


### PR DESCRIPTION
Hi Philip,

This patch fixes an issue with the following IDL code:

Export
Constraint SimpleForTest
  ({x} control flow dominates {y} and
  {y} has control flow to {x} and {x} is first successor of {y} and
  {code} spans block to {y} and
  {code} is first successor of {x}
  )
End