### PR TITLE
Add a preprocessor to include IDL files

### DIFF
--- a/lib/IDLParser/CMakeLists.txt
+++ b/lib/IDLParser/CMakeLists.txt
@@ -1,17 +1,24 @@
 add_llvm_library(LLVMIDLParser
   ${CMAKE_CURRENT_BINARY_DIR}/IdiomSpecifications.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/PreprocessedIDL.idl
 
   DEPENDS
   idl_parser
   intrinsics_gen
 )
 
+FILE(GLOB IDL_SOURCES *.idl)
 set(CMAKE_CXX_STANDARD 20)
 add_executable(idl_parser
     Parser.cc
 )
 
+ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/PreprocessedIDL.idl
+                   COMMAND pypy ${CMAKE_CURRENT_SOURCE_DIR}/preprocess.py Idioms.idl -d ${CMAKE_CURRENT_SOURCE_DIR} > ${CMAKE_CURRENT_BINARY_DIR}/PreprocessedIDL.idl
+                   DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/preprocess.py "${IDL_SOURCES}"
+                   COMMENT "Preprocess the IDL file")
+
 ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IdiomSpecifications.cpp
-                   COMMAND idl_parser ${CMAKE_CURRENT_SOURCE_DIR}/IDL.bnf ${CMAKE_CURRENT_SOURCE_DIR}/Idioms.idl | pypy ${CMAKE_CURRENT_SOURCE_DIR}/stage3.py > ${CMAKE_CURRENT_BINARY_DIR}/IdiomSpecifications.cpp
-                   DEPENDS idl_parser  ${CMAKE_CURRENT_SOURCE_DIR}/IDL.bnf ${CMAKE_CURRENT_SOURCE_DIR}/Idioms.idl ${CMAKE_CURRENT_SOURCE_DIR}/stage3.py
+                  COMMAND idl_parser ${CMAKE_CURRENT_SOURCE_DIR}/IDL.bnf ${CMAKE_CURRENT_BINARY_DIR}/PreprocessedIDL.idl | pypy ${CMAKE_CURRENT_SOURCE_DIR}/stage3.py > ${CMAKE_CURRENT_BINARY_DIR}/IdiomSpecifications.cpp
+                  DEPENDS idl_parser  ${CMAKE_CURRENT_SOURCE_DIR}/IDL.bnf ${CMAKE_CURRENT_SOURCE_DIR}/stage3.py ${CMAKE_CURRENT_BINARY_DIR}/PreprocessedIDL.idl
                    COMMENT "Generate idiom specifications C++ file")

--- a/lib/IDLParser/preprocess.py
+++ b/lib/IDLParser/preprocess.py
@@ -1,0 +1,43 @@
+import argparse
+import sys
+import os
+
+visited_files = []
+
+def preprocess(file, dir=None):
+    global visited_files
+    # Don't include a file more than once.
+    if dir and file:
+        file = dir + os.path.sep + file
+    if file in visited_files:
+        return
+    visited_files.append(file)
+
+    f = None
+    try:
+        if file is None:
+            f = sys.stdin
+        else:
+            f = open(file)
+
+        # Preprocess everything else also:
+        for line in f.readlines():
+            if line.startswith('Include '):
+                include_file = line.split(' ')[1].strip()
+                preprocess(include_file, dir=dir)
+            else:
+              print(line)
+    finally:
+        if file is not None:
+            if f:
+                f.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Preprocessor for IDL")
+
+    parser.add_argument("filename", nargs='?', default=None)
+    parser.add_argument("-d", dest='dir', help="Include directory to find files in", default=None)
+    args = parser.parse_args()
+
+    preprocess(args.filename, args.dir)


### PR DESCRIPTION
Hi Philip,

This adds a preprocessor command, "Include filename" to IDL. The aim is to make it a bit easier to deal with really large IDL files, and (particularly in my case) separate very different types of functionality.

There is an a-cyclicalness check, so every file can include all of its dependencies.

Example use is:
```
Include VectorOps.idl
Include Loops.idl

Export Constraint ....
End
```

Replaces #4 

Also, I haven't been able to test this because I haven't been able to build since the preprocessor update.

Jackson