### PR TITLE
Find and link OpenBLAS explicitly

### DIFF
--- a/lilac/CMakeLists.txt
+++ b/lilac/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(OpenBLAS REQUIRED)
+
 add_custom_target(lilac_target
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Idioms.idl
           ${CMAKE_CURRENT_BINARY_DIR}/CustomPassReplacerLiLACGenerated.h
@@ -47,7 +49,8 @@ add_library(spmv_jds_naive SHARED
     ${CMAKE_CURRENT_BINARY_DIR}/spmv_jds_naive.cc
 )
 
-target_link_libraries(gemm_openblas openblas)
+target_link_libraries(gemm_openblas ${OpenBLAS_LIBRARIES})
+target_include_directories(gemm_openblas PRIVATE ${OpenBLAS_INCLUDE_DIRS})
 
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
This means that OpenBLAS no longer has to be installed somewhere
globally visible on the evaluation system; it can be installed elsewhere
and discovered using `-DOpenBLAS_DIR` at the CMake invocation.